### PR TITLE
Set `returnUrl` URL param as required

### DIFF
--- a/packages/app/src/providers/provider.tsx
+++ b/packages/app/src/providers/provider.tsx
@@ -55,6 +55,7 @@ export function IdentityProvider({
 
   const clientId = getParamFromUrl('clientId')
   const scope = getParamFromUrl('scope')
+  const returnUrl = getParamFromUrl('returnUrl')
 
   useEffect(() => {
     dispatch({ type: 'identity/onLoad' })
@@ -74,7 +75,7 @@ export function IdentityProvider({
     }
   }, [clientId, scope])
 
-  if (clientId == null || scope == null) {
+  if (clientId == null || scope == null || returnUrl == null) {
     return (
       <PageErrorLayout statusCode={500} message='Missing required parameter.' />
     )


### PR DESCRIPTION
### What does this PR do?
Set `returnUrl` URL param as required in `identity` provider. In case `returnUrl` is not defined it will be shown the `Missing required parameter.` error screen.