### PR TITLE
Add `expires` returnUrl param after a successful login

### DIFF
--- a/packages/app/@typing/Settings.d.ts
+++ b/packages/app/@typing/Settings.d.ts
@@ -22,6 +22,11 @@ declare module 'App' {
      */
     customerAccessToken?: string
     /**
+     * Access Token expiry date for a sales channel API credentials obtained using login password flow.
+     * Read more at {@link https://docs.commercelayer.io/core/authentication/client-credentials#password}, {@link https://docs.commercelayer.io/core/authentication/password}
+     */
+    customerAccessTokenExpires?: string
+    /**
      * Organization slug.
      * Read more at {@link https://docs.commercelayer.io/core/v/api-reference/organization/object}.
      */

--- a/packages/app/src/components/forms/LoginForm.tsx
+++ b/packages/app/src/components/forms/LoginForm.tsx
@@ -50,8 +50,9 @@ export const LoginForm = (): JSX.Element => {
       .then((tokenData) => {
         if (tokenData.accessToken != null) {
           redirectToReturnUrl({
+            scope: tokenData.scope,
             accessToken: tokenData.accessToken,
-            scope: tokenData.scope
+            expires: tokenData.expires.toISOString()
           })
         } else {
           form.setError('root', {

--- a/packages/app/src/components/forms/SignUpForm.tsx
+++ b/packages/app/src/components/forms/SignUpForm.tsx
@@ -73,8 +73,9 @@ export const SignUpForm = (): JSX.Element => {
         .then((tokenData) => {
           if (tokenData.accessToken != null) {
             redirectToReturnUrl({
+              scope: tokenData.scope,
               accessToken: tokenData.accessToken,
-              scope: tokenData.scope
+              expires: tokenData.expires.toISOString()
             })
           }
         })

--- a/packages/app/src/utils/redirectToReturnUrl.ts
+++ b/packages/app/src/utils/redirectToReturnUrl.ts
@@ -4,8 +4,9 @@ import { getParamFromUrl } from '#utils/getParamFromUrl'
 import type { Settings } from 'App'
 
 interface RedirectToReturnUrlConfig {
-  accessToken: Settings['accessToken']
   scope: Settings['scope']
+  accessToken: Settings['customerAccessToken']
+  expires: Settings['customerAccessTokenExpires']
 }
 
 /**
@@ -15,8 +16,9 @@ interface RedirectToReturnUrlConfig {
  * @param scope - String specified during the authentication flow to restrict the scope of obtained access token to a market and/or to a stock location.
  */
 export const redirectToReturnUrl = ({
+  scope,
   accessToken,
-  scope
+  expires
 }: RedirectToReturnUrlConfig): void => {
   const returnUrl = getParamFromUrl('returnUrl')
   if (returnUrl != null && window !== undefined) {
@@ -24,6 +26,9 @@ export const redirectToReturnUrl = ({
     const url = new URL(returnUrl)
     url.searchParams.append('accessToken', accessToken ?? '')
     url.searchParams.append('scope', scope)
+    if (expires != null) {
+      url.searchParams.append('expires', expires)
+    }
     topWindow.location.href = url.href
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I updated the redirect method launched after a successful customer login to send a new additional `expires` GET param to the `returnUrl`. The `expires` param will contain the ISO date generated from the token `expires` `Date` returned by the `js-auth` library.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
