### PR TITLE
Add support for `private` scope

### DIFF
--- a/packages/app/@typing/Settings.d.ts
+++ b/packages/app/@typing/Settings.d.ts
@@ -7,10 +7,20 @@ declare module "App" {
     clientId: string
     /**
      * String specified during the authentication flow to restrict the scope of obtained access token to a market and/or to a stock location.
-     * Example: `market:1234` or `stock_location:4567` or `market:1234 stock_location:4567`
+     * Example: `market:id:a2sb3re4` or `stock_location:id:c4s5m6e7` or `market:id:a2sb3re4 stock_location:id:c4s5m6e7`
+     *
+     * A scope could be eventually related to a private market (restricted to a customer group).
+     * If the provided scope is meant to be private, the `publicScope` param should be set as well
+     * to provide a suitable public market scope used to gather generic organization information.
+     *
      * Read more at {@link https://docs.commercelayer.io/core/authentication#authorization-scopes}
      */
     scope: string
+    /**
+     * Additional scope used to obtain an access token valid for public organization data in case the `scope` param is a private scope.
+     * Read more at {@link https://docs.commercelayer.io/core/authentication#authorization-scopes}
+     */
+    publicScope?: string
     /**
      * Access Token for a sales channel API credentials to be used to authenticate all Commerce Layer API requests.
      * Read more at {@link https://docs.commercelayer.io/core/authentication/client-credentials#sales-channel}, {@link https://docs.commercelayer.io/core/authentication/client-credentials}

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -37,7 +37,7 @@ window.clAppConfig = {
 
 4. Create a [sales channel](https://docs.commercelayer.io/core/applications#sales-channel) application inside your organization and take note of its client ID.
 
-5. Setup and/or identify a [scope](https://docs.commercelayer.io/core/authentication#authorization-scopes) containing a market [e.g. `market:1234`] as required by the sales channel [authentication](https://docs.commercelayer.io/core/authentication/client-credentials#sales-channel).
+5. Setup and/or identify a [scope](https://docs.commercelayer.io/core/authentication#authorization-scopes) containing a market [e.g. `market:id:a2sb3re4`] as required by the sales channel [authentication](https://docs.commercelayer.io/core/authentication/client-credentials#sales-channel).
 
 6. Define a valid return URL that will be reached upon a successful login and/or sign-up procedure.
 
@@ -46,7 +46,7 @@ window.clAppConfig = {
 ### Example
 
 ```http
-https://identity.yourbrand.com?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:1234&returnUrl=https://shop.yourbrand.com/
+https://identity.yourbrand.com?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:id:a2sb3re4&returnUrl=https://shop.yourbrand.com/
 ```
 
 ## Hosted version
@@ -58,7 +58,7 @@ You can use the hosted version of the Identity application with the following UR
 ### Example
 
 ```http
-https://yourbrand.commercelayer.app/identity?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:1234&returnUrl=https://shop.yourbrand.com/
+https://yourbrand.commercelayer.app/identity?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:id:a2sb3re4&returnUrl=https://shop.yourbrand.com/
 ```
 
 ## Custom reset password flow
@@ -68,7 +68,7 @@ In addition to the previously defined GET parameters required for correctly gene
 ### Example
 
 ```http
-https://yourbrand.commercelayer.app/identity?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:1234&returnUrl=https://shop.yourbrand.com/&resetPasswordUrl=https://www.yourbrand.com/customer/reset-password
+https://yourbrand.commercelayer.app/identity?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:id:a2sb3re4&returnUrl=https://shop.yourbrand.com/&resetPasswordUrl=https://www.yourbrand.com/customer/reset-password
 ```
 
 ## Contributors guide

--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -12,6 +12,7 @@ The Commerce Layer Identity micro frontend (React) provides you with an applicat
 
 - [Getting started](#getting-started)
 - [Hosted version](#hosted-version)
+- [Private markets](#private-markets)
 - [Custom reset password flow](#custom-reset-password-flow)
 - [Contributors guide](#contributors-guide)
 - [Running on Windows](#running-on-windows)
@@ -26,7 +27,7 @@ The Commerce Layer Identity micro frontend (React) provides you with an applicat
 
 2. Configure the `selfHostedSlug` property in `/public/config.local.js` to match your organization slug (subdomain). If this file does not exist, create it using the following content:
 
-```
+```js
 window.clAppConfig = {
   domain: "commercelayer.io",
   selfHostedSlug: "<your-org-slug>",
@@ -35,9 +36,9 @@ window.clAppConfig = {
 
 3. Deploy the forked repository to your preferred hosting service.
 
-4. Create a [sales channel](https://docs.commercelayer.io/core/applications#sales-channel) application inside your organization and take note of its client ID.
+4. Create a [sales channel](https://docs.commercelayer.io/core/api-credentials#sales-channel) API credential within your organization and take note of the client ID.
 
-5. Setup and/or identify a [scope](https://docs.commercelayer.io/core/authentication#authorization-scopes) containing a market [e.g. `market:id:a2sb3re4`] as required by the sales channel [authentication](https://docs.commercelayer.io/core/authentication/client-credentials#sales-channel).
+5. Define a valid [scope](https://docs.commercelayer.io/core/authentication#authorization-scopes) as required by the sales channel [authentication](https://docs.commercelayer.io/core/authentication/client-credentials#sales-channel). It will be used to restrict the dataset of your application to a market, a stock location or a set of them.
 
 6. Define a valid return URL that will be reached upon a successful login and/or sign-up procedure.
 
@@ -45,8 +46,8 @@ window.clAppConfig = {
 
 ### Example
 
-```http
-https://identity.yourbrand.com?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:id:a2sb3re4&returnUrl=https://shop.yourbrand.com/
+```text
+https://identity.yourbrand.com?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:code:worldwide&returnUrl=https://shop.yourbrand.com/
 ```
 
 ## Hosted version
@@ -57,8 +58,22 @@ You can use the hosted version of the Identity application with the following UR
 
 ### Example
 
-```http
-https://yourbrand.commercelayer.app/identity?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:id:a2sb3re4&returnUrl=https://shop.yourbrand.com/
+```text
+https://yourbrand.commercelayer.app/identity?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:code:worldwide&returnUrl=https://shop.yourbrand.com/
+```
+
+## Private markets
+
+When you associate a [customer group](https://docs.commercelayer.io/core/api-reference/customer_groups) with a market, that market becomes private and can be accessed only by customers belonging to the group. You can use private markets to handle scenarios where you need dedicated price lists, custom shipping methods, or other specific features available for a restricted pool of customers, such as managing B2B deals, B2C loyalty programs, private sales, and more.
+
+To enable this kind of use cases, the `mfe-identity` application expects to have both required `scope` and optional `publicScope` parameters defined:
+- `scope` - the market to be used for the login process (e.g. a private market).
+- `publicScope` - the default scope used by the app to obtain the organization settings needed to customize the UI (name, logo, colors, etc.).
+
+### Example
+
+```text
+https://yourbrand.commercelayer.app/identity?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:code:vip&publicScope=market:code:worldwide&returnUrl=https://shop.yourbrand.com/
 ```
 
 ## Custom reset password flow
@@ -67,8 +82,8 @@ In addition to the previously defined GET parameters required for correctly gene
 
 ### Example
 
-```http
-https://yourbrand.commercelayer.app/identity?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:id:a2sb3re4&returnUrl=https://shop.yourbrand.com/&resetPasswordUrl=https://www.yourbrand.com/customer/reset-password
+```text
+https://yourbrand.commercelayer.app/identity?clientId=eyJhbGciOiJIUzUxMiJ9&scope=market:code:worldwide&returnUrl=https://shop.yourbrand.com/&resetPasswordUrl=https://www.yourbrand.com/customer/reset-password
 ```
 
 ## Contributors guide
@@ -77,26 +92,27 @@ https://yourbrand.commercelayer.app/identity?clientId=eyJhbGciOiJIUzUxMiJ9&scope
 
 2. Clone the forked repository like so:
 
-```bash
+```sh
 git clone https://github.com/<your username>/mfe-identity.git && cd mfe-identity
 ```
 
 3. First, install dependencies and run the development server:
 
-```
+```sh
 pnpm install
 pnpm dev
 ```
 
 4. (Optional) Set your environment with `.env.local` starting from `.env.local.sample`.
 
-5. Open [http://localhost:5174](http://localhost:5174) with your browser to see the result. You can use the following format to open the login page: `http://localhost:5174/identity/?clientId=<your-client-id>&scope=<your-scope>&returnUrl=<your-return-url>`
+5. Open [http://localhost:5173](http://localhost:5173) with your browser to see the result. You can use the following format to open the login page: `http://localhost:5173/identity/?clientId=<your-client-id>&scope=<your-scope>&returnUrl=<your-return-url>`
 
 6. Make your changes and create a pull request ([learn how to do this](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/creating-a-pull-request)).
 
 7. Someone will attend to your pull request and provide some feedback.
 
 ## Running on Windows
+
 When working on Microsoft Windows, we suggest to use the PowerShell terminal or any alternative shell with the ability to run scripts as admin user.
 
 This is required to install `pnpm` following the instruction [here](https://pnpm.io/installation#on-windows).

--- a/packages/app/src/components/forms/SignUpForm.tsx
+++ b/packages/app/src/components/forms/SignUpForm.tsx
@@ -11,6 +11,7 @@ import { Input } from "#components/atoms/Input"
 import { appRoutes } from "#data/routes"
 import { useIdentityContext } from "#providers/provider"
 import { getParamFromUrl } from "#utils/getParamFromUrl"
+import { redirectToLoginUrl } from "#utils/redirectToLoginUrl"
 import { redirectToReturnUrl } from "#utils/redirectToReturnUrl"
 
 import type { SignUpFormValues } from "Forms"
@@ -76,12 +77,27 @@ export const SignUpForm = (): JSX.Element => {
               accessToken: tokenData.accessToken,
               expires: tokenData.expires.toISOString(),
             })
+          } else {
+            redirectToLoginUrl({
+              loginUrl: `${window.location.protocol}//${window.location.host}${router.base}${appRoutes.login.makePath()}`,
+              clientId: settings.clientId,
+              scope: settings.scope,
+              publicScope: settings.publicScope,
+              returnUrl: getParamFromUrl("returnUrl") ?? "",
+              resetPasswordUrl: getParamFromUrl("resetPasswordUrl") ?? "",
+              customerEmail: formData.customerEmail ?? "",
+            })
           }
         })
         .catch(() => {
-          form.setError("root", {
-            type: "custom",
-            message: "Invalid credentials",
+          redirectToLoginUrl({
+            loginUrl: `${window.location.protocol}//${window.location.host}${router.base}${appRoutes.login.makePath()}`,
+            clientId: settings.clientId,
+            scope: settings.scope,
+            publicScope: settings.publicScope,
+            returnUrl: getParamFromUrl("returnUrl") ?? "",
+            resetPasswordUrl: getParamFromUrl("resetPasswordUrl") ?? "",
+            customerEmail: formData.customerEmail ?? "",
           })
         })
     }

--- a/packages/app/src/components/forms/ValidationApiError.tsx
+++ b/packages/app/src/components/forms/ValidationApiError.tsx
@@ -1,3 +1,4 @@
+import { isEmpty } from "lodash"
 import { useEffect } from "react"
 import { useFormContext } from "react-hook-form"
 import { Alert } from "#components/atoms/Alert"
@@ -30,7 +31,7 @@ function ValidationApiError({
   const { setError, getValues } = useFormContext()
 
   useEffect(() => {
-    if (apiError != null) {
+    if (apiError != null && !isEmpty(apiError?.errors)) {
       setApiFormErrors({
         apiError,
         setError,

--- a/packages/app/src/providers/provider.tsx
+++ b/packages/app/src/providers/provider.tsx
@@ -55,13 +55,14 @@ export function IdentityProvider({
 
   const clientId = getParamFromUrl("clientId") ?? ""
   const scope = getParamFromUrl("scope") ?? ""
+  const publicScope = getParamFromUrl("publicScope") ?? undefined
   const returnUrl = getParamFromUrl("returnUrl") ?? ""
 
   useEffect(() => {
     dispatch({ type: "identity/onLoad" })
 
     if (clientId != null && scope != null) {
-      getSettings({ clientId, scope, config })
+      getSettings({ clientId, scope, publicScope, config })
         .then((settings) => {
           if (settings.isValid) {
             dispatch({ type: "identity/loaded", payload: settings })
@@ -73,7 +74,7 @@ export function IdentityProvider({
           dispatch({ type: "identity/onError" })
         })
     }
-  }, [clientId, scope, config])
+  }, [clientId, scope, config, publicScope])
 
   if (clientId.length === 0 || scope.length === 0 || returnUrl.length === 0) {
     return (

--- a/packages/app/src/utils/getParamFromUrl.ts
+++ b/packages/app/src/utils/getParamFromUrl.ts
@@ -1,6 +1,7 @@
 type UrlParam =
   | "clientId"
   | "scope"
+  | "publicScope"
   | "returnUrl"
   | "resetPasswordUrl"
   | "customerEmail"

--- a/packages/app/src/utils/getSettings.ts
+++ b/packages/app/src/utils/getSettings.ts
@@ -1,6 +1,7 @@
 import CommerceLayer from "@commercelayer/sdk"
 import type { InvalidSettings, Settings } from "App"
 
+import { isEmpty } from "lodash"
 import { getOrganization } from "#utils/getOrganization"
 import { getSubdomain } from "#utils/getSubdomain"
 import { getStoredSalesChannelToken } from "#utils/oauthStorage"
@@ -24,6 +25,7 @@ const makeInvalidSettings = (): InvalidSettings => ({
 
 type GetSettingsProps = Pick<Settings, "clientId" | "scope"> & {
   config: CommerceLayerAppConfig
+  publicScope?: Settings["publicScope"]
 }
 
 /**
@@ -31,6 +33,7 @@ type GetSettingsProps = Pick<Settings, "clientId" | "scope"> & {
  *
  * @param clientId - Commerce Layer application's clientId.
  * @param scope - Commerce Layer access token scope (market, stock location).
+ * @param publicScope - Commerce Layer access token scope suitable for public organization data in case main `scope` param is related to a private scope.
  * @param config - Commerce Layer app configuration available from global window object.
  * Read more at {@link https://docs.commercelayer.io/developers/authentication/client-credentials#sales-channel}, {@link https://docs.commercelayer.io/core/authentication/password}
  *
@@ -39,6 +42,7 @@ type GetSettingsProps = Pick<Settings, "clientId" | "scope"> & {
 export const getSettings = async ({
   clientId,
   scope,
+  publicScope,
   config,
 }: GetSettingsProps): Promise<Settings | InvalidSettings> => {
   const hostname = window !== undefined ? window.location.hostname : ""
@@ -54,7 +58,7 @@ export const getSettings = async ({
       slug,
       domain,
       clientId,
-      scope,
+      scope: !isEmpty(publicScope) && publicScope != null ? publicScope : scope,
     }),
   )
 
@@ -82,6 +86,7 @@ export const getSettings = async ({
   return {
     clientId,
     scope,
+    publicScope,
     accessToken: storedToken?.access_token ?? "",
     isValid: true,
     companySlug: slug,

--- a/packages/app/src/utils/oauthStorage.ts
+++ b/packages/app/src/utils/oauthStorage.ts
@@ -77,7 +77,11 @@ interface GetStoredSalesChannelTokenConfig {
   scope: string
 }
 
-// TODO: Define if storageKey needs a naming differentiation for sales channel tokens and customer tokens
+/**
+ * Retrieve and store a Sales Channel `accessToken` used by the app to obtain organization settings and perform suitable requests.
+ * @param config - Configuration object containing parameters needed by the Sales Channel authentication procedure.
+ * @returns an access token data set, if available, or `null`.
+ */
 export const getStoredSalesChannelToken = async ({
   app,
   slug,

--- a/packages/app/src/utils/redirectToLoginUrl.ts
+++ b/packages/app/src/utils/redirectToLoginUrl.ts
@@ -1,0 +1,44 @@
+import { isEmbedded } from "#utils/isEmbedded"
+
+import type { Settings } from "App"
+
+interface RedirectToLoginUrlConfig {
+  loginUrl: string
+  clientId: Settings["clientId"]
+  scope: Settings["scope"]
+  publicScope?: Settings["publicScope"]
+  returnUrl?: string
+  resetPasswordUrl?: string
+  customerEmail?: string
+}
+
+/**
+ * Redirects to loginUrl adding available get parameters.
+ */
+export const redirectToLoginUrl = ({
+  loginUrl,
+  clientId,
+  scope,
+  publicScope,
+  returnUrl,
+  resetPasswordUrl,
+  customerEmail,
+}: RedirectToLoginUrlConfig): void => {
+  const topWindow = isEmbedded() ? window.parent : window
+  const url = new URL(loginUrl)
+  url.searchParams.append("clientId", clientId)
+  url.searchParams.append("scope", scope)
+  if (publicScope != null) {
+    url.searchParams.append("publicScope", publicScope)
+  }
+  if (returnUrl != null) {
+    url.searchParams.append("returnUrl", returnUrl)
+  }
+  if (resetPasswordUrl != null) {
+    url.searchParams.append("resetPasswordUrl", resetPasswordUrl)
+  }
+  if (customerEmail != null) {
+    url.searchParams.append("customerEmail", customerEmail)
+  }
+  topWindow.location.href = url.href
+}


### PR DESCRIPTION
Closes #26 

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Added support for `private` scopes by introducing an optional `publicScope` URL param. This param could be filled with a public scope string in case the required `scope` URL param is expected to contain a private scope string, for example to permit the login only to customers matching a customer group associated to a market.

If the `publicScope` parameter is set it is used (instead of required `scope` parameter) to obtain and store a valid Sales Channel access token and to gather the organization settings (logo, colors, etc) to customize the application UI.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
