### PR TITLE
Add customer reset password page

### DIFF
--- a/packages/app/src/App.tsx
+++ b/packages/app/src/App.tsx
@@ -6,6 +6,7 @@ import { InjectCssCustomProperties } from "#components/InjectCssCustomProperties
 import { PageErrorLayout } from "#components/layouts/PageErrorLayout"
 import { appRoutes } from "#data/routes"
 import LoginPage from "#pages/LoginPage"
+import ResetPasswordPage from "#pages/ResetPassword"
 import SignUpPage from "#pages/SignUpPage"
 import { IdentityProvider } from "#providers/provider"
 
@@ -32,6 +33,9 @@ function App(): JSX.Element {
                 </Route>
                 <Route path={appRoutes.signUp.path}>
                   <SignUpPage />
+                </Route>
+                <Route path={appRoutes.resetPassword.path}>
+                  <ResetPasswordPage />
                 </Route>
                 <Route>
                   <PageErrorLayout statusCode={404} message="Page not found" />

--- a/packages/app/src/components/forms/ResetPasswordForm.tsx
+++ b/packages/app/src/components/forms/ResetPasswordForm.tsx
@@ -1,0 +1,88 @@
+import CommerceLayer, { CommerceLayerStatic } from "@commercelayer/sdk"
+import { yupResolver } from "@hookform/resolvers/yup"
+import { FormProvider, useForm } from "react-hook-form"
+import * as yup from "yup"
+
+import { Button } from "#components/atoms/Button"
+import { Input } from "#components/atoms/Input"
+import { useIdentityContext } from "#providers/provider"
+
+import { useState } from "react"
+import { ValidationApiError } from "./ValidationApiError"
+
+const validationSchema = yup.object().shape({
+  password: yup.string().required("Password is required"),
+  confirmPassword: yup
+    .string()
+    .required("Confirm password is required")
+    .oneOf([yup.ref("password"), ""], "Passwords must match"),
+})
+
+type ResetPasswordFormValues = yup.InferType<typeof validationSchema>
+
+interface ResetPasswordFormProps {
+  customerPasswordResetId: string
+  resetPasswordToken: string
+  onSuccess: () => void
+}
+
+export const ResetPasswordForm = ({
+  customerPasswordResetId,
+  resetPasswordToken,
+  onSuccess,
+}: ResetPasswordFormProps): JSX.Element => {
+  const { settings, config } = useIdentityContext()
+  const [apiError, setApiError] = useState({})
+
+  const form = useForm<ResetPasswordFormValues>({
+    resolver: yupResolver(validationSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  })
+
+  const isSubmitting = form.formState.isSubmitting
+
+  const onSubmit = form.handleSubmit(async (formData) => {
+    const client = CommerceLayer({
+      organization: settings.companySlug,
+      accessToken: settings.accessToken,
+      domain: config.domain,
+    })
+
+    try {
+      await client.customer_password_resets.update({
+        id: customerPasswordResetId ?? "",
+        _reset_password_token: resetPasswordToken ?? "",
+        customer_password: formData.password,
+      })
+      onSuccess()
+    } catch (e: unknown) {
+      const apiError = {
+        errors: CommerceLayerStatic.isApiError(e)
+          ? e.errors
+          : "Problem resetting password. Please try again or contact support.",
+      }
+      setApiError(apiError)
+    }
+  })
+
+  return (
+    <FormProvider {...form}>
+      <form className="mt-8 mb-0" onSubmit={onSubmit}>
+        <div className="space-y-4">
+          <Input name="password" label="Password" type="password" />
+          <Input
+            name="confirmPassword"
+            label="Confirm password"
+            type="password"
+          />
+          <div className="flex pt-4">
+            <Button disabled={isSubmitting} type="submit">
+              {isSubmitting ? "..." : "Set password"}
+            </Button>
+          </div>
+          <ValidationApiError apiError={apiError} />
+        </div>
+      </form>
+    </FormProvider>
+  )
+}

--- a/packages/app/src/data/routes.ts
+++ b/packages/app/src/data/routes.ts
@@ -13,4 +13,8 @@ export const appRoutes = {
     path: "/signup",
     makePath: () => "/signup",
   },
+  resetPassword: {
+    path: "/reset-password",
+    makePath: () => "/reset-password",
+  },
 }

--- a/packages/app/src/pages/ResetPassword.tsx
+++ b/packages/app/src/pages/ResetPassword.tsx
@@ -1,0 +1,49 @@
+import { isEmpty } from "lodash"
+import { useState } from "react"
+import { Alert } from "#components/atoms/Alert"
+import { PageHeading } from "#components/atoms/PageHeading"
+import { ResetPasswordForm } from "#components/forms/ResetPasswordForm"
+import { LayoutDefault } from "#components/layouts/LayoutDefault"
+import { getParamFromUrl } from "#utils/getParamFromUrl"
+
+export default function ResetPasswordPage(): JSX.Element {
+  const [showSuccess, setShowSuccess] = useState(false)
+  const customerPasswordResetId = getParamFromUrl("customerPasswordResetId")
+  const resetPasswordToken = getParamFromUrl("resetPasswordToken")
+
+  if (
+    isEmpty(customerPasswordResetId) ||
+    customerPasswordResetId == null ||
+    isEmpty(resetPasswordToken) ||
+    resetPasswordToken == null
+  ) {
+    return (
+      <LayoutDefault>
+        <Alert variant="danger" title="Invalid password reset link." />
+      </LayoutDefault>
+    )
+  }
+
+  if (showSuccess) {
+    return (
+      <LayoutDefault>
+        <Alert
+          variant="success"
+          title="Your password has been reset successfully. You can close this
+            window."
+        />
+      </LayoutDefault>
+    )
+  }
+
+  return (
+    <LayoutDefault>
+      <PageHeading title="Reset Password" description="Enter a new password." />
+      <ResetPasswordForm
+        customerPasswordResetId={customerPasswordResetId}
+        resetPasswordToken={resetPasswordToken}
+        onSuccess={() => setShowSuccess(true)}
+      />
+    </LayoutDefault>
+  )
+}

--- a/packages/app/src/utils/getOrganization.ts
+++ b/packages/app/src/utils/getOrganization.ts
@@ -32,6 +32,7 @@ const getAsyncOrganization = async (
         "favicon_url",
         "gtm_id",
         "gtm_id_test",
+        "slug",
         "support_email",
         "support_phone",
       ],

--- a/packages/app/src/utils/getParamFromUrl.ts
+++ b/packages/app/src/utils/getParamFromUrl.ts
@@ -5,6 +5,8 @@ type UrlParam =
   | "returnUrl"
   | "resetPasswordUrl"
   | "customerEmail"
+  | "customerPasswordResetId"
+  | "resetPasswordToken"
 
 /**
  * @returns the value of specified query string parameter or `undefined` if it's not present.

--- a/packages/app/src/utils/getSettings.ts
+++ b/packages/app/src/utils/getSettings.ts
@@ -1,6 +1,5 @@
 import CommerceLayer from "@commercelayer/sdk"
 import type { InvalidSettings, Settings } from "App"
-
 import { isEmpty } from "lodash"
 import { getOrganization } from "#utils/getOrganization"
 import { getSubdomain } from "#utils/getSubdomain"
@@ -67,7 +66,7 @@ export const getSettings = async ({
   }
 
   const client = CommerceLayer({
-    organization: slug,
+    organization: storedToken?.slug ?? "",
     accessToken: storedToken?.access_token ?? "",
     domain,
   })
@@ -89,7 +88,7 @@ export const getSettings = async ({
     publicScope,
     accessToken: storedToken?.access_token ?? "",
     isValid: true,
-    companySlug: slug,
+    companySlug: organization?.slug ?? slug,
     companyName: organization?.name ?? defaultSettings.companyName,
     primaryColor: organization?.primary_color ?? defaultSettings.primaryColor,
     logoUrl: organization?.logo_url ?? "",

--- a/packages/app/src/utils/oauthStorage.ts
+++ b/packages/app/src/utils/oauthStorage.ts
@@ -13,6 +13,7 @@ interface StoredOauthResponse {
   error_description?: string
   client_id?: string
   expires?: number
+  slug?: string
 }
 
 interface GetStoredTokenKeyConfig {
@@ -108,6 +109,7 @@ export const getStoredSalesChannelToken = async ({
         scope,
         token_type: auth.tokenType,
         expires: decodedJWT.payload.exp,
+        slug: slug,
       }
       const storageKey = getStoredTokenKey({ app, slug, scope })
       localStorage.setItem(storageKey, JSON.stringify(tokenData))


### PR DESCRIPTION
Closes commercelayer/issues-app#467

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

I've added a new route to reset password.
This new route `/reset-password` needs some parameters to work:
- customerPasswordResetId (The ID of the `customer_password_reset` resource created from an integration)
- resetPasswordToken (The `reset_password_token` that the user has received)
- scope (can be always `market:all`)
- returnUrl (if you have an URL to handle the reset success page you can use it here, otherwise this can be set to `none` so the success message will appear inline)

 
<img width="572" height="719" alt="image" src="https://github.com/user-attachments/assets/30cef7e6-e649-4099-9438-ede75c4ed970" />

----

<img width="558" height="435" alt="image" src="https://github.com/user-attachments/assets/788b4dbd-4980-49bf-a3f5-adda79baa40b" />

## How to test

<!-- Please include the steps to test your changes here -->

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [ ] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [ ] You are **NOT** deprecating/removing a feature.
