### PR TITLE
Use node 24 in vulnerability workflow

### DIFF
--- a/.github/workflows/vulnerability-updates.yaml
+++ b/.github/workflows/vulnerability-updates.yaml
@@ -24,5 +24,6 @@ jobs:
       run_test: true
       run_build: true
       run_check: false
+      node_version: 24.x
       issue_number: ${{ github.event_name == 'issues' && github.event.issue.number || '' }}
     secrets: inherit


### PR DESCRIPTION
<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Set node version 24 in vulnerability workflow to avoid issues with incompatible/deprecated versions.