### PR TITLE
Require the `returnUrl` to be absolute

### DIFF
--- a/packages/app/README.md
+++ b/packages/app/README.md
@@ -41,7 +41,7 @@ window.clAppConfig = {
 
 5. Define a valid [scope](https://docs.commercelayer.io/core/authentication#authorization-scopes) as required by the sales channel [authentication](https://docs.commercelayer.io/core/authentication/client-credentials#sales-channel). It will be used to restrict the dataset of your application to a market, a stock location or a set of them.
 
-6. Define a valid return URL that will be reached upon a successful login and/or sign-up procedure.
+6. Define a valid return URL that will be reached upon a successful login and/or sign-up procedure. It must be an absolute URL, including scheme (`http://` or `https://`) and host (e.g. `https://shop.yourbrand.com/`) — a relative path (e.g. `/checkout`) is not accepted and results in an error.
 
 7. Open the identity app using the URL format: `<your-deployed-identity-url>?clientId=<your-client-id>&scope=<your-scope>&returnUrl=<your-return-url>`.
 

--- a/packages/app/specs/e2e/0-app-setup.spec.ts
+++ b/packages/app/specs/e2e/0-app-setup.spec.ts
@@ -30,6 +30,16 @@ test.describe("app setup", () => {
     await expect(page.getByText("Missing required parameter.")).toBeVisible()
   })
 
+  test("shows error when returnUrl is not an absolute URL", async ({
+    page,
+  }) => {
+    await page.goto(buildLoginUrl({ returnUrl: "/dashboard" }))
+
+    await expect(
+      page.getByText("Invalid returnUrl: it must be an absolute URL."),
+    ).toBeVisible()
+  })
+
   test("supports encoded returnUrl query values", async ({ page }) => {
     await page.goto(
       buildLoginUrl({

--- a/packages/app/src/providers/provider.tsx
+++ b/packages/app/src/providers/provider.tsx
@@ -15,6 +15,7 @@ import type {
 } from "#providers/types"
 import { getParamFromUrl } from "#utils/getParamFromUrl"
 import { getSettings } from "#utils/getSettings"
+import { isAbsoluteUrl } from "#utils/isAbsoluteUrl"
 
 interface IdentityProviderProps {
   /**
@@ -87,6 +88,15 @@ export function IdentityProvider({
   if (clientId.length === 0 || scope.length === 0 || returnUrl.length === 0) {
     return (
       <PageErrorLayout statusCode={500} message="Missing required parameter." />
+    )
+  }
+
+  if (!isAbsoluteUrl(returnUrl)) {
+    return (
+      <PageErrorLayout
+        statusCode={500}
+        message="Invalid returnUrl: it must be an absolute URL."
+      />
     )
   }
 

--- a/packages/app/src/utils/getParamFromUrl.ts
+++ b/packages/app/src/utils/getParamFromUrl.ts
@@ -19,11 +19,6 @@ export const getParamFromUrl = (param: UrlParam): string | null | undefined => {
     if (param === "customerEmail") {
       return params.get(param)?.replace(" ", "+")
     }
-    if (param === "returnUrl") {
-      return params.get(param)?.slice(0, 1) === "/"
-        ? params.get(param)?.slice(1)
-        : params.get(param)
-    }
     return params.get(param)
   }
 }

--- a/packages/app/src/utils/isAbsoluteUrl.ts
+++ b/packages/app/src/utils/isAbsoluteUrl.ts
@@ -1,0 +1,13 @@
+/**
+ * @returns `true` if the given string is an absolute URL with an `http:` or `https:` scheme, `false` otherwise.
+ *
+ * @param url: the string to check.
+ */
+export const isAbsoluteUrl = (url: string): boolean => {
+  try {
+    const { protocol } = new URL(url)
+    return protocol === "http:" || protocol === "https:"
+  } catch {
+    return false
+  }
+}

--- a/packages/app/src/utils/redirectToReturnUrl.ts
+++ b/packages/app/src/utils/redirectToReturnUrl.ts
@@ -22,16 +22,7 @@ export const redirectToReturnUrl = ({
   const returnUrl = getParamFromUrl("returnUrl")
   if (returnUrl != null && window !== undefined) {
     const topWindow = isEmbedded() ? window.parent : window
-    let url: URL
-    try {
-      url = new URL(returnUrl)
-    } catch {
-      const base =
-        document.referrer !== ""
-          ? document.referrer
-          : `${window.location.origin}/${import.meta.env.PUBLIC_PROJECT_PATH}/`
-      url = new URL(returnUrl, base)
-    }
+    const url = new URL(returnUrl)
     url.searchParams.append("accessToken", accessToken ?? "")
     url.searchParams.append("scope", scope)
     if (expires != null) {


### PR DESCRIPTION
Closes #74 

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Rolled back `relative` URL compatibility of `returnUrl` URL param by definitively enforcing it to be absolute in order to avoid misleading/unwanted behaviors and actually untracked/unsupported scenarios.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [x] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
