### PR TITLE
Fix `returnUrl` to not being required for reset password flow

### DIFF
--- a/packages/app/src/providers/provider.tsx
+++ b/packages/app/src/providers/provider.tsx
@@ -56,6 +56,9 @@ export function IdentityProvider({
   const isAppUrl = Object.values(appRoutes).some(({ path }) =>
     currentPath.startsWith(path),
   )
+  const isPasswordResetUrl = currentPath.startsWith(
+    appRoutes.resetPassword.path,
+  )
 
   const clientId = getParamFromUrl("clientId") ?? ""
   const scope = getParamFromUrl("scope") ?? ""
@@ -91,7 +94,7 @@ export function IdentityProvider({
     )
   }
 
-  if (!isAbsoluteUrl(returnUrl)) {
+  if (!isPasswordResetUrl && !isAbsoluteUrl(returnUrl)) {
     return (
       <PageErrorLayout
         statusCode={500}


### PR DESCRIPTION
Closes #77 

<!-- Thank you for contributing to Commerce Layer! If your PR is related to an issue, provide the number(s) above; if it resolves multiple issues, be sure to break them up (e.g. "closes #1000, closes #1001"). -->

## What I did

Relaxed `returnUrl` validation for password reset URL.

## Checklist

<!-- Please check (put an "x" inside the "[ ]") the applicable items below to make sure your PR is ready to be reviewed. -->

- [x] Make sure your changes are tested (stories and/or unit, integration, or end-to-end tests).
- [ ] Make sure to add/update documentation regarding your changes.
- [x] You are **NOT** deprecating/removing a feature.
